### PR TITLE
fix: comment `dist` on `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 .DS_Store
-dist
+# dist
 dist-ssr
 *.local


### PR DESCRIPTION
I'll comment this line so the `dist` folder can be included and deployed